### PR TITLE
fix/cache break images with srcset

### DIFF
--- a/app/Cache.php
+++ b/app/Cache.php
@@ -54,7 +54,7 @@ class Cache {
 		$url = add_query_arg( 'image-crop-positioner-ts', $updated_date, $url );
 		return $url;
 	}
-	
+
 	public function change_attachment_srcset( array $sources, array $size_array, string $image_src, array $image_meta, int $attachment_id ): array {
 		$updated_date = ( new AttachmentMeta() )->get_updated_timestamp( $attachment_id );
 		if ( ! $updated_date ) {

--- a/app/Cache.php
+++ b/app/Cache.php
@@ -10,6 +10,7 @@ class Cache {
 		add_action( 'updated_post_meta', array( $this, 'store_updated_date' ), 10, 3 );
 		add_filter( 'wp_get_attachment_image_src', array( $this, 'change_attachment_src' ), 11, 2 );
 		add_filter( 'wp_get_attachment_url', array( $this, 'change_attachment_url' ), 11, 2 );
+		add_filter( 'wp_calculate_image_srcset', array( $this, 'change_attachment_srcset' ), 11, 5 );
 	}
 
 	public function store_updated_date( int $meta_id, int $attachment_id, string $meta_key ): void {
@@ -52,5 +53,18 @@ class Cache {
 
 		$url = add_query_arg( 'image-crop-positioner-ts', $updated_date, $url );
 		return $url;
+	}
+	
+	public function change_attachment_srcset( array $sources, array $size_array, string $image_src, array $image_meta, int $attachment_id ): array {
+		$updated_date = ( new AttachmentMeta() )->get_updated_timestamp( $attachment_id );
+		if ( ! $updated_date ) {
+			return $sources;
+		}
+
+		foreach ( $sources as &$source ) {
+			$source['url'] = add_query_arg( 'image-crop-positioner-ts', $updated_date, $source['url'] );
+		}
+
+		return $sources;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
Closes https://github.com/mentosmenno2/image-crop-positioner/issues/31

## Description
<!--- Describe your changes in detail -->
Fixes issue where images with a srcset would not have the cache breaker added to the url.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
