### PR TITLE
Fix wrong parameter type in cache.php

### DIFF
--- a/app/Cache.php
+++ b/app/Cache.php
@@ -27,12 +27,13 @@ class Cache {
 
 	/**
 	 * @param array|false $image
-	 * @param integer $attachment_id
+	 * @param int|string $attachment_id
 	 * @param string $size
 	 * @return array|false
 	 */
-	public function change_attachment_src( $image, int $attachment_id ) {
-		if ( ! is_array( $image ) || ! isset( $image[0] ) ) {
+	public function change_attachment_src( $image, $attachment_id ) {
+		$attachment_id = (int) $attachment_id;
+		if ( ! is_array( $image ) || ! isset( $image[0] ) || ! $attachment_id ) {
 			return $image;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->

## Description
<!--- Describe your changes in detail -->
Fixes issue where plugins are old-scool, and pass id's as strings.
Which would crash, because we require an integer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
