### PR TITLE
Do not replace attachment urls (also fixes broken Download Monitor downloads)

### DIFF
--- a/app/Cache.php
+++ b/app/Cache.php
@@ -8,9 +8,8 @@ class Cache {
 
 	public function register_hooks(): void {
 		add_action( 'updated_post_meta', array( $this, 'store_updated_date' ), 10, 3 );
-		add_filter( 'wp_get_attachment_image_src', array( $this, 'change_attachment_src' ), 11, 2 );
-		add_filter( 'wp_get_attachment_url', array( $this, 'change_attachment_url' ), 11, 2 );
-		add_filter( 'wp_calculate_image_srcset', array( $this, 'change_attachment_srcset' ), 11, 5 );
+		add_filter( 'wp_get_attachment_image_src', array( $this, 'change_attachment_image_src' ), 11, 2 );
+		add_filter( 'wp_calculate_image_srcset', array( $this, 'change_attachment_image_srcset' ), 11, 5 );
 	}
 
 	public function store_updated_date( int $meta_id, int $attachment_id, string $meta_key ): void {
@@ -26,27 +25,38 @@ class Cache {
 	}
 
 	/**
+	 * Change the source of the attachment
+	 *
 	 * @param array|false $image
 	 * @param int|string $attachment_id
 	 * @param string $size
 	 * @return array|false
 	 */
-	public function change_attachment_src( $image, $attachment_id ) {
+	public function change_attachment_image_src( $image, $attachment_id ) {
 		$attachment_id = (int) $attachment_id;
 		if ( ! is_array( $image ) || ! isset( $image[0] ) || ! $attachment_id ) {
 			return $image;
 		}
 
-		$updated_date = ( new AttachmentMeta() )->get_updated_timestamp( $attachment_id );
-		if ( ! $updated_date ) {
-			return $image;
-		}
-
-		$image[0] = $this->change_attachment_url( $image[0], $attachment_id );
+		$image[0] = $this->change_attachment_image_url( $image[0], $attachment_id );
 		return $image;
 	}
 
-	public function change_attachment_url( string $url, int $attachment_id ): string {
+	/**
+	 * Change the sourceset of the attachment
+	 */
+	public function change_attachment_image_srcset( array $sources, array $size_array, string $image_src, array $image_meta, int $attachment_id ): array {
+		foreach ( $sources as &$source ) {
+			$source['url'] = $this->change_attachment_image_url( $source['url'], $attachment_id );
+		}
+
+		return $sources;
+	}
+
+	/**
+	 * Add the updated timestamp to the url of an image
+	 */
+	protected function change_attachment_image_url( string $url, int $attachment_id ): string {
 		$updated_date = ( new AttachmentMeta() )->get_updated_timestamp( $attachment_id );
 		if ( ! $updated_date ) {
 			return $url;
@@ -54,18 +64,5 @@ class Cache {
 
 		$url = add_query_arg( 'image-crop-positioner-ts', $updated_date, $url );
 		return $url;
-	}
-
-	public function change_attachment_srcset( array $sources, array $size_array, string $image_src, array $image_meta, int $attachment_id ): array {
-		$updated_date = ( new AttachmentMeta() )->get_updated_timestamp( $attachment_id );
-		if ( ! $updated_date ) {
-			return $sources;
-		}
-
-		foreach ( $sources as &$source ) {
-			$source['url'] = add_query_arg( 'image-crop-positioner-ts', $updated_date, $source['url'] );
-		}
-
-		return $sources;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
Fixes https://github.com/mentosmenno2/image-crop-positioner/issues/37

## Description
<!--- Describe your changes in detail -->
Fixes issue where the actual attachment url was modified by the cache breaker functionality (url parameter).
This would for example cause downloads of the [Download Monitor](https://nl.wordpress.org/plugins/download-monitor/) plugin to not work.
Replacing the actual attachment URL is not needed, as images should be displayed by using the image source instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

1. Install download monitor plugin
2. Upload a JPEG file via the WordPress media library (only tested with *.jpg, not with *.jpeg)
3. Create a download in the Download Manager plugin and reference the JPEG file from step 2 as download
4. Save the download
5. Copy the link shown in a side widget called 'Download info'
6. Navigate to the copied link
7. It downloads the real image file, instead of html.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
