### PR TITLE
Fix image bucket base64 fallback for JS faces detection

### DIFF
--- a/templates/admin/attachment-edit-fields.php
+++ b/templates/admin/attachment-edit-fields.php
@@ -24,9 +24,9 @@ $image_src      = wp_get_attachment_image_src( $attachment->ID, 'full' )[0] ?? '
 
 // If image is hosted on external url (like an image bucket), convert it to a data image.
 if ( strpos( $image_src, home_url() ) !== 0 ) {
-	$image_data = wp_remote_get( $image_src ) ?: '';
-	if ( ! $image_data instanceof WP_Error && ! empty( $image_data['body'] ) && ! empty( $image_data['content-type'] ) ) {
-		$image_src = 'data:' . $image_data['content-type'] . ';base64,' . base64_encode( $image_data['body'] ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+	$image_data = wp_remote_get( $image_src, array( 'timeout' => 5 ) ) ?: '';
+	if ( ! $image_data instanceof WP_Error && ! empty( $image_data['body'] ) && ! empty( $image_data['headers']['content-type'] ) ) {
+		$image_src = 'data:' . $image_data['headers']['content-type'] . ';base64,' . base64_encode( $image_data['body'] ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
Fixes https://github.com/mentosmenno2/image-crop-positioner/issues/43

## Description
<!--- Describe your changes in detail -->
Fixes issue in generating a base64 image when an image is hosted on an external source, like an image bucket.
This base64 image is required for JS faces detection to work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally, by forcing the image source to be an external url.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
