### PR TITLE
Fix/downscaled images autodetection

### DIFF
--- a/app/Ajax/FaceDetection.php
+++ b/app/Ajax/FaceDetection.php
@@ -28,7 +28,7 @@ class FaceDetection extends BaseAjaxCall {
 	 * Detect faces from attachment, save it in the meta, and send them to the json response.
 	 */
 	protected function detect_faces( int $attachment_id ): void {
-		$file = wp_get_original_image_path( $attachment_id );
+		$file = get_attached_file( $attachment_id );
 		if ( ! is_string( $file ) ) {
 			$error = new WP_Error(
 				400, __( 'Attachment has no file path.', 'image-crop-positioner' ), array(

--- a/app/FaceDetection/AutoDetect.php
+++ b/app/FaceDetection/AutoDetect.php
@@ -42,7 +42,7 @@ class AutoDetect {
 		}
 
 		// If already autodetected, skip.
-		if ( ( new AttachmentMeta() )->get_faces_autodetected( $attachment_id, true ) ) {
+		if ( ( new AttachmentMeta() )->get_faces_autodetected( $attachment_id ) ) {
 			return;
 		}
 

--- a/app/Helpers/AttachmentMeta.php
+++ b/app/Helpers/AttachmentMeta.php
@@ -66,7 +66,7 @@ class AttachmentMeta {
 	public function get_faces_autodetected( int $attachment_id ): bool {
 		$autodetected = get_post_meta( $attachment_id, self::META_KEY_FACES_AUTODETECTED, true );
 		if ( ! is_scalar( $autodetected ) ) {
-			$autodetected = 0;
+			$autodetected = false;
 		}
 
 		return (bool) $autodetected;

--- a/app/Helpers/AttachmentMeta.php
+++ b/app/Helpers/AttachmentMeta.php
@@ -7,9 +7,10 @@ use Mentosmenno2\ImageCropPositioner\Objects\Hotspot;
 
 class AttachmentMeta {
 
-	public const META_KEY_UPDATED_TIMESTAMP = 'image_crop_positioner_updated_timestamp';
-	public const META_KEY_FACES             = 'image_crop_positioner_faces';
-	public const META_KEY_HOTSPOTS          = 'image_crop_positioner_hotspots';
+	public const META_KEY_UPDATED_TIMESTAMP  = 'image_crop_positioner_updated_timestamp';
+	public const META_KEY_FACES              = 'image_crop_positioner_faces';
+	public const META_KEY_HOTSPOTS           = 'image_crop_positioner_hotspots';
+	public const META_KEY_FACES_AUTODETECTED = 'image_crop_positioner_faces_autodetected';
 
 	/**
 	 * @param integer $attachment_id
@@ -60,6 +61,19 @@ class AttachmentMeta {
 			}, $faces
 		);
 		update_post_meta( $attachment_id, self::META_KEY_FACES, $faces_data );
+	}
+
+	public function get_faces_autodetected( int $attachment_id ): bool {
+		$autodetected = get_post_meta( $attachment_id, self::META_KEY_FACES_AUTODETECTED, true );
+		if ( ! is_scalar( $autodetected ) ) {
+			$autodetected = 0;
+		}
+
+		return (bool) $autodetected;
+	}
+
+	public function set_faces_autodetected( int $attachment_id, bool $autodetected ): void {
+		update_post_meta( $attachment_id, self::META_KEY_FACES_AUTODETECTED, $autodetected );
 	}
 
 	/**

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,4 +1,4 @@
 # Requirements
 
 - PHP 7.3+
-- WordPress 5.2+
+- WordPress 5.3+

--- a/image-crop-positioner.php
+++ b/image-crop-positioner.php
@@ -8,7 +8,7 @@
  * Author URI:        https://github.com/mentosmenno2
  * Text Domain:       image-crop-positioner
  * Domain Path:       /languages
- * Requires at least: 5.2
+ * Requires at least: 5.3
  * Requires PHP:      7.3
  * Update URI:        https://github.com/mentosmenno2/image-crop-positioner
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
Fixes https://github.com/mentosmenno2/image-crop-positioner/issues/55

## Description
<!--- Describe your changes in detail -->
Fixes an issue that autodetected faces on the original image instead of the downscaled image by wordpress.
This was caused by attachment meta not beeing generated yet, resulting in the original image beeing used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've uploaded the example image as provided in the original issue.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/12169252/162064045-76494d8d-dd82-4fc9-969a-d04def876262.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
