### PR TITLE
Improve performance of CLI migrate command with batches

### DIFF
--- a/app/CLI/Migrate.php
+++ b/app/CLI/Migrate.php
@@ -18,21 +18,21 @@ class Migrate {
 	 * <migrator_slug>
 	 * : Slug of a migrator
 	 *
-	 * [--per-page=<int>]
-	 * : How many attachments are in a page. Use -1 for all attachments.
+	 * [--batch-size=<int>]
+	 * : How many attachments are processed in a batch. Use -1 for all attachments.
 	 * ---
-	 * default: -1
+	 * default: 100
 	 * ---
 	 *
-	 * [--page=<int>]
-	 * : The page you want to process
+	 * [--batch-number=<int>]
+	 * : The batch number you want to start processing from
 	 * ---
 	 * default: 1
 	 * ---
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp image-crop-positioner migrate attachments my_eyes_are_up_here --per-page=100 --page=1
+	 *     wp image-crop-positioner migrate attachments my_eyes_are_up_here --batch-size=100 --batch-number=1
 	 */
 	public function attachments( array $args, array $assoc_args ): void {
 		$migrator_slug = $args[0];
@@ -41,31 +41,39 @@ class Migrate {
 			WP_CLI::error( sprintf( 'Migrator does not exist. Please select one of: %s', implode( ', ', array_keys( $migrators ) ) ) );
 		}
 
-		$per_page = (int) ( $assoc_args['per-page'] ?? -1 );
-		$page     = (int) ( $assoc_args['page'] ?? 1 );
+		$migrator     = $migrators[ $migrator_slug ];
+		$batch_size   = (int) ( $assoc_args['batch-size'] ?? 100 );
+		$batch_number = (int) ( $assoc_args['batch-number'] ?? 1 );
+		$posts_count  = 0;
+		$total_count  = 0;
+		$first_run    = true;
 
-		WP_CLI::log( "Retrieving attachments (page: $page, per page: $per_page)" );
+		while ( $first_run || $posts_count ) {
+			$first_run = false;
 
-		$migrator    = new MyEyesAreUpHere();
-		$wp_query    = $migrator->get_migratable_attachment_ids( $page, $per_page );
-		$posts_count = $wp_query->post_count;
+			WP_CLI::log( "Getting new batch (batch number: $batch_number, batch size: $batch_size)" );
+			$wp_query     = $migrator->get_migratable_attachment_ids( $batch_number, $batch_size );
+			$posts_count  = $wp_query->post_count;
+			$total_count += $posts_count;
+			WP_CLI::log( "Processing batch (batch number: $batch_number, batch size: $batch_size, items in batch: $posts_count)" );
 
-		/** @var int[] */
-		$posts = $wp_query->posts;
-		foreach ( $posts as $index => $post_id ) {
-			WP_CLI::log( "Migrating attachment ID: $post_id" );
-			$status = $migrator->migrate_attachment( $post_id );
-			if ( $status === MyEyesAreUpHere::STATUS_DONE ) {
-				WP_CLI::log( "Migrated attachment ID: $post_id" );
-			} else {
-				WP_CLI::log( "Skipped attachment ID: $post_id" );
+			/** @var int[] */
+			$posts = $wp_query->posts;
+			foreach ( $posts as $post_id ) {
+				WP_CLI::log( "Migrating attachment ID: $post_id" );
+				$status = $migrator->migrate_attachment( $post_id );
+				if ( $status === MyEyesAreUpHere::STATUS_DONE ) {
+					WP_CLI::log( "Migrated attachment ID: $post_id" );
+				} else {
+					WP_CLI::log( "Skipped attachment ID: $post_id" );
+				}
 			}
 
-			$done = (int) $index + 1;
-			if ( $done % self::PROGRESS_DISPLAY_BATCH_SIZE === 0 ) {
-				WP_CLI::colorize( "%pMigrated $done of $posts_count attachments%n" );
-			}
+			WP_CLI::log( "Processed batch (batch number: $batch_number, batch size: $batch_size, items in batch: $posts_count, total items processed: $total_count)" );
+
+			$batch_number++;
 		}
-		WP_CLI::success( "All $posts_count attachments have been migrated" );
+
+		WP_CLI::success( "All $total_count attachments have been migrated" );
 	}
 }

--- a/docs/wp-cli-commands.md
+++ b/docs/wp-cli-commands.md
@@ -27,6 +27,6 @@ wp image-crop-positioner face-detection save-image "\path\to\input_image.jpg" "\
 Run a migration for all attachments
 
 ```sh
-wp image-crop-positioner migrate attachments regenerate_images --per-page=100 --page=1
-wp image-crop-positioner migrate attachments my_eyes_are_up_here --per-page=100 --page=1
+wp image-crop-positioner migrate attachments regenerate_images --batch-size=100 --batch-number=1
+wp image-crop-positioner migrate attachments my_eyes_are_up_here --batch-size=100 --batch-number=1
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
<!--- Link to the origin of the issue in Asana or HelpScout. -->
Fixes #65 

## Description
<!--- Describe your changes in detail -->
How the CLI migrate commando is used has been changed.

- You can define a batch size (default 100)
- You can specify a batch number to start from (default 1)

It will now keep processing from your starting batch number untill all images have been migrated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running `wp image-crop-positioner migrate attachments my_eyes_are_up_here --batch-size=2 --batch-number=4`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
