### PR TITLE
Feature/async base64 images

### DIFF
--- a/app/Ajax/EncodeImage.php
+++ b/app/Ajax/EncodeImage.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Mentosmenno2\ImageCropPositioner\Ajax;
+
+use WP_Error;
+
+class EncodeImage extends BaseAjaxCall {
+
+	public function register_hooks(): void {
+		add_action( 'wp_ajax_image_crop_positioner_encode_image', array( $this, 'handle_request' ) );
+	}
+
+	/**
+	 * Handle the request
+	 */
+	public function handle_request(): void {
+		$this->validate_nonce();
+		$attachment_id = (int) filter_input( INPUT_POST, 'attachment_id', FILTER_VALIDATE_INT );
+		$this->validate_is_attachment( $attachment_id );
+		$this->validate_attachment_is_image( $attachment_id );
+
+		$this->get_base64_image( $attachment_id );
+	}
+
+	/**
+	 * Get the image source converted to base64 if possible.
+	 * Otherwise get the original source.
+	 */
+	protected function get_base64_image( int $attachment_id ): void {
+
+		// Attempt with local file
+		// $file_path = get_attached_file( $attachment_id ) ?: '';
+		// $mime_type = mime_content_type( $file_path );
+		// $file_content = file_get_contents( $file_path ) ?: '';
+		// if ( $file_path && $mime_type && $file_content ) {
+		// 	$base64 = 'data:' . $mime_type . ';base64,' . base64_encode( $file_content ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		// 	$this->return_success_response( $base64 );
+		// 	exit;
+		// }
+
+		// Attempt with remote get
+		$image_src = wp_get_attachment_image_src( $attachment_id, 'full' )[0] ?? '';
+		$image_src = 'https://i.postimg.cc/mgZLf18r/image.png';
+		$image_data = wp_remote_get(
+			$image_src,
+			array(
+				'timeout' => 10
+			)
+		);
+		if ( ! $image_data instanceof WP_Error && ! empty( $image_data['body'] ) && ! empty( $image_data['headers']['content-type'] ) && strpos( $image_data['headers']['content-type'], 'image/' ) === 0 ) {
+			$image_src = 'data:' . $image_data['headers']['content-type'] . ';base64,' . base64_encode( $image_data['body'] ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			$this->return_success_response( $image_src );
+			exit;
+		}
+
+		// If both fail, return the original source
+		$this->return_success_response(
+			$image_src,
+			new WP_Error(
+				400, __( 'Could not get base64 data for image.', 'image-crop-positioner' ), array(
+					'status' => 400,
+				)
+			)
+		);
+		exit;
+	}
+
+	protected function return_success_response( string $src, ?WP_Error $download_debug_data = null ): void {
+		wp_send_json_success( array(
+			'src' => $src,
+			'download_debug_data' => $download_debug_data,
+		), 200 );
+		exit;
+	}
+}

--- a/app/Ajax/EncodeImage.php
+++ b/app/Ajax/EncodeImage.php
@@ -29,8 +29,8 @@ class EncodeImage extends BaseAjaxCall {
 	protected function get_base64_image( int $attachment_id ): void {
 
 		// Attempt with local file
-		$file_path = get_attached_file( $attachment_id ) ?: '';
-		$mime_type = mime_content_type( $file_path );
+		$file_path    = get_attached_file( $attachment_id ) ?: '';
+		$mime_type    = mime_content_type( $file_path );
 		$file_content = file_get_contents( $file_path ) ?: '';
 		if ( $file_path && $mime_type && $file_content ) {
 			$base64 = 'data:' . $mime_type . ';base64,' . base64_encode( $file_content ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
@@ -39,11 +39,11 @@ class EncodeImage extends BaseAjaxCall {
 		}
 
 		// Attempt with remote get
-		$image_src = wp_get_attachment_image_src( $attachment_id, 'full' )[0] ?? '';
+		$image_src  = wp_get_attachment_image_src( $attachment_id, 'full' )[0] ?? '';
 		$image_data = wp_remote_get(
 			$image_src,
 			array(
-				'timeout' => 10
+				'timeout' => 10,
 			)
 		);
 		if ( ! $image_data instanceof WP_Error && ! empty( $image_data['body'] ) && ! empty( $image_data['headers']['content-type'] ) && strpos( $image_data['headers']['content-type'], 'image/' ) === 0 ) {
@@ -65,10 +65,12 @@ class EncodeImage extends BaseAjaxCall {
 	}
 
 	protected function return_success_response( string $src, ?WP_Error $download_debug_data = null ): void {
-		wp_send_json_success( array(
-			'src' => $src,
-			'download_debug_data' => $download_debug_data,
-		), 200 );
+		wp_send_json_success(
+			array(
+				'src'                 => $src,
+				'download_debug_data' => $download_debug_data,
+			), 200
+		);
 		exit;
 	}
 }

--- a/app/Ajax/EncodeImage.php
+++ b/app/Ajax/EncodeImage.php
@@ -31,7 +31,7 @@ class EncodeImage extends BaseAjaxCall {
 		// Attempt with local file
 		$file_path    = get_attached_file( $attachment_id ) ?: '';
 		$mime_type    = mime_content_type( $file_path );
-		$file_content = file_get_contents( $file_path ) ?: '';
+		$file_content = file_get_contents( $file_path ) ?: ''; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		if ( $file_path && $mime_type && $file_content ) {
 			$base64 = 'data:' . $mime_type . ';base64,' . base64_encode( $file_content ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			$this->return_success_response( $base64 );

--- a/app/Ajax/EncodeImage.php
+++ b/app/Ajax/EncodeImage.php
@@ -29,18 +29,17 @@ class EncodeImage extends BaseAjaxCall {
 	protected function get_base64_image( int $attachment_id ): void {
 
 		// Attempt with local file
-		// $file_path = get_attached_file( $attachment_id ) ?: '';
-		// $mime_type = mime_content_type( $file_path );
-		// $file_content = file_get_contents( $file_path ) ?: '';
-		// if ( $file_path && $mime_type && $file_content ) {
-		// 	$base64 = 'data:' . $mime_type . ';base64,' . base64_encode( $file_content ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		// 	$this->return_success_response( $base64 );
-		// 	exit;
-		// }
+		$file_path = get_attached_file( $attachment_id ) ?: '';
+		$mime_type = mime_content_type( $file_path );
+		$file_content = file_get_contents( $file_path ) ?: '';
+		if ( $file_path && $mime_type && $file_content ) {
+			$base64 = 'data:' . $mime_type . ';base64,' . base64_encode( $file_content ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			$this->return_success_response( $base64 );
+			exit;
+		}
 
 		// Attempt with remote get
 		$image_src = wp_get_attachment_image_src( $attachment_id, 'full' )[0] ?? '';
-		$image_src = 'https://i.postimg.cc/mgZLf18r/image.png';
 		$image_data = wp_remote_get(
 			$image_src,
 			array(

--- a/image-crop-positioner.php
+++ b/image-crop-positioner.php
@@ -81,6 +81,7 @@ add_action(
 		( new Mentosmenno2\ImageCropPositioner\Ajax\SaveFaces() )->register_hooks();
 		( new Mentosmenno2\ImageCropPositioner\Ajax\RemoveFaces() )->register_hooks();
 		( new Mentosmenno2\ImageCropPositioner\Ajax\SaveHotspots() )->register_hooks();
+		( new Mentosmenno2\ImageCropPositioner\Ajax\EncodeImage() )->register_hooks();
 		( new Mentosmenno2\ImageCropPositioner\FaceDetection\AutoDetect() )->register_hooks();
 
 		// Register CLI commands

--- a/src/scripts/global/edit-image-screen.js
+++ b/src/scripts/global/edit-image-screen.js
@@ -225,9 +225,12 @@ import SpinnerHelper from "../helpers/spinner";
 			disableAllDetections();
 			spinnerHelper.appendToElement( getDetectFacesJsButton() );
 
-			// If hosted on same domain, detect faces after a small delay
+			// If hosted on same domain, detect faces after a small delay to allow for the spinner to be shown
 			if ( ! config.is_external ) {
-				detectFacesJsBackgroundTask();
+				setTimeout( () => {
+					detectFacesJsBackgroundTask();
+				}, 1 );
+				return;
 			}
 
 			// Download the base64 of the image and use it for faces detection

--- a/src/scripts/global/edit-image-screen.js
+++ b/src/scripts/global/edit-image-screen.js
@@ -54,7 +54,10 @@ import SpinnerHelper from "../helpers/spinner";
 			getDiscardHotspotsButton().on( 'click', function() { discardHotspots(); } );
 			getSaveHotspotsButton().on( 'click', function() { saveHotspots(); } );
 
-			getPreviewImage().on( 'load', function() { previewImageLoaded(); } );
+			getPreviewImage().on( 'load', function() {
+				getPreviewImage().off( 'load' );
+				previewImageLoaded();
+			} );
 		}
 
 		function previewImageLoaded() {
@@ -214,17 +217,47 @@ import SpinnerHelper from "../helpers/spinner";
 
 		function detectFacesJs() {
 			if ( devTools.isOpen ) {
-				adminNoticeHelper.setToElementHtml( getFaceDetectionMessage(), 'Face detection via JavaScript does not work when devtools is open. Please close your devtools and try again.', 'error' );
-				return;
+
+				// eslint-disable-next-line no-console
+				console.warning( 'Image crop positioner: JavaScript face detection somehow might not work when devtools is open. If that is the case, please close devtools and try again.' );
 			}
 
 			disableAllDetections();
 			spinnerHelper.appendToElement( getDetectFacesJsButton() );
 
-			// Put it in a setTimeout so JavaScript will run it a little bit later, making sure the spinner works.
-			setTimeout( () => {
-				detectFacesJsBackgroundTask();
-			}, 0 );
+			$.ajax( {
+				url : window.image_crop_positioner_options.ajax_url,
+				data : {
+					_ajax_nonce: window.image_crop_positioner_options.nonce,
+					action: 'image_crop_positioner_encode_image',
+					attachment_id: config.attachment_id
+				},
+				method : 'POST',
+				dataType: "json",
+				timeout: 30000,
+			} )
+				.done( function( data ) {
+					const $previewImageElement = getPreviewImage();
+					const currentSrc = $previewImageElement.attr( 'src' );
+					if ( currentSrc === data.data.src ) {
+						detectFacesJsBackgroundTask();
+						return;
+					}
+
+					$previewImageElement.on( 'load', function() {
+						$previewImageElement.off( 'load' );
+						detectFacesJsBackgroundTask();
+					} );
+					$previewImageElement.attr( 'src', data.data.src );
+				} )
+				.fail( function( jqXHR ) {
+					let errorMessage = 'Error';
+					if ( typeof jqXHR.responseJSON !== 'undefined' && typeof jqXHR.responseJSON.data[ 0 ].message !== 'undefined' ) {
+						errorMessage = jqXHR.responseJSON.data[ 0 ].message;
+					}
+					enableAllDetections();
+					adminNoticeHelper.setToElementHtml( getFaceDetectionMessage(), errorMessage, 'error' );
+				} );
 		}
 
 		function detectFacesJsBackgroundTask() {

--- a/src/scripts/global/edit-image-screen.js
+++ b/src/scripts/global/edit-image-screen.js
@@ -225,6 +225,12 @@ import SpinnerHelper from "../helpers/spinner";
 			disableAllDetections();
 			spinnerHelper.appendToElement( getDetectFacesJsButton() );
 
+			// If hosted on same domain, detect faces after a small delay
+			if ( ! config.is_external ) {
+				detectFacesJsBackgroundTask();
+			}
+
+			// Download the base64 of the image and use it for faces detection
 			$.ajax( {
 				url : window.image_crop_positioner_options.ajax_url,
 				data : {

--- a/templates/admin/attachment-edit-fields.php
+++ b/templates/admin/attachment-edit-fields.php
@@ -22,6 +22,7 @@ $faces               = $attachmentmeta->get_faces( $attachment->ID );
 $hotspots            = $attachmentmeta->get_hotspots( $attachment->ID );
 $image_src           = wp_get_attachment_image_src( $attachment->ID, 'full' )[0] ?? '';
 $attachment_metadata = wp_get_attachment_metadata( $attachment->ID ) ?: array();
+$is_external  = strpos( $image_src, home_url() ) !== 0;
 
 $data_config = wp_json_encode(
 	array(
@@ -30,6 +31,7 @@ $data_config = wp_json_encode(
 		'attachment_metadata' => $attachment_metadata,
 		'faces'               => $faces,
 		'hotspots'            => $hotspots,
+		'is_external'         => $is_external,
 		'js_faces_detection'  => array(
 			'min_accuracy' => ( new JSFacesDetectionMinAccuracy() )->get_value(),
 		),

--- a/templates/admin/attachment-edit-fields.php
+++ b/templates/admin/attachment-edit-fields.php
@@ -22,7 +22,7 @@ $faces               = $attachmentmeta->get_faces( $attachment->ID );
 $hotspots            = $attachmentmeta->get_hotspots( $attachment->ID );
 $image_src           = wp_get_attachment_image_src( $attachment->ID, 'full' )[0] ?? '';
 $attachment_metadata = wp_get_attachment_metadata( $attachment->ID ) ?: array();
-$is_external  = strpos( $image_src, home_url() ) !== 0;
+$is_external         = strpos( $image_src, home_url() ) !== 0;
 
 $data_config = wp_json_encode(
 	array(

--- a/templates/admin/attachment-edit-fields.php
+++ b/templates/admin/attachment-edit-fields.php
@@ -23,14 +23,6 @@ $hotspots            = $attachmentmeta->get_hotspots( $attachment->ID );
 $image_src           = wp_get_attachment_image_src( $attachment->ID, 'full' )[0] ?? '';
 $attachment_metadata = wp_get_attachment_metadata( $attachment->ID ) ?: array();
 
-// If image is hosted on external url (like an image bucket), convert it to a data image.
-if ( strpos( $image_src, home_url() ) !== 0 ) {
-	$image_data = wp_remote_get( $image_src, array( 'timeout' => 5 ) ) ?: '';
-	if ( ! $image_data instanceof WP_Error && ! empty( $image_data['body'] ) && ! empty( $image_data['headers']['content-type'] ) && strpos( $image_data['headers']['content-type'], 'image/' ) === 0 ) {
-		$image_src = 'data:' . $image_data['headers']['content-type'] . ';base64,' . base64_encode( $image_data['body'] ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-	}
-}
-
 $data_config = wp_json_encode(
 	array(
 		'attachment_id'       => $attachment->ID,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
Fixes #66 

## Description
<!--- Describe your changes in detail -->
The performance for remotely hosted images was rather slow.
This was because to make JS face detection work, the image had to be downloaded and converted to base64 encoding.
And this downloading of the attachment was done directly when viewing the attachment.

This PR changes that whole behavior. The base64 is only downloaded when the attachment is hosted externally, and is now downloaded after pressing the Detect faces with JS button.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If possible, include details of your testing environment, and/or tests you ran. -->
I've forced the type of the image to be an externally hosted image, and forced the url to be an externally hosted image as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate):
