### PR TITLE
disable auto detect

### DIFF
--- a/app/Admin/Settings/PHPFaceDetection/Fields/AutoDetectOnUpload.php
+++ b/app/Admin/Settings/PHPFaceDetection/Fields/AutoDetectOnUpload.php
@@ -30,6 +30,6 @@ class AutoDetectOnUpload extends BaseToggleField {
 	}
 
 	public function get_default_value(): bool {
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue link
Fixes #<!--- Number of the issue in GitHub. -->
na

## Description
<!--- Describe your changes in detail -->
By default disables the auto detect setting via PHP.
The reality seems to be that this is in the way a lot of the time and just too heavy.

This change might influence the setting on existing sites if they have never modified the plugin settings.
Sites which have modified the settings, it will be kept.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If possible, include details of your testing environment, and/or tests you ran. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate):
